### PR TITLE
chore: highlight methods with `@function.method`

### DIFF
--- a/lua/namu/namu_symbols/init.lua
+++ b/lua/namu/namu_symbols/init.lua
@@ -326,7 +326,7 @@ function M.setup_highlights()
   local highlights = {
     NamuPrefixSymbol = { link = "@Comment" }, -- or "@lsp.type.symbol"
     NamuSymbolFunction = { link = "@function" },
-    NamuSymbolMethod = { link = "@variable" },
+    NamuSymbolMethod = { link = "@function.method" },
     NamuSymbolClass = { link = "@lsp.type.class" },
     NamuSymbolInterface = { link = "@lsp.type.interface" },
     NamuSymbolVariable = { link = "@lsp.type.variable" },


### PR DESCRIPTION
## Context

Tree-sitter has a specific highlight group for methods, [@function.method](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#functions), which popular color schemes like [Tokyo Night](https://github.com/folke/tokyonight.nvim/blob/c8ea87cd34b0267c44a67e90ff8f6e7d6af46ff9/extras/lua/tokyonight_moon.lua#L126) and my own [OneDarkPro.nvim](https://github.com/olimorris/onedarkpro.nvim/blob/4a18713a99080b3cd3e541728e35d2b4aac21e9d/lua/onedarkpro/highlights/plugins/treesitter.lua#L55) make use of.

Also, a lot of users may have custom highlighting which overwrites @function.method.

## Change

This PR _proposes_ that by default, Namu, will color any methods using `@function.method`. Of course, this assumes that the user has Tree-sitter installed.