### PR TITLE
Vertical split mapping fix

### DIFF
--- a/lua/namu/namu_symbols/init.lua
+++ b/lua/namu/namu_symbols/init.lua
@@ -296,6 +296,28 @@ M.config = {
       desc = "Open in vertical split",
     },
     {
+      key = "<C-h>",
+      handler = function(item, selecta_state)
+        if not state.original_buf then
+          vim.notify("No original buffer available", vim.log.levels.ERROR)
+          return
+        end
+
+        local new_win = selecta.open_in_split(selecta_state, item, "horizontal", state)
+        if new_win then
+          local symbol = item.value
+          if symbol and symbol.lnum and symbol.col then
+            -- Set cursor to symbol position
+            pcall(vim.api.nvim_win_set_cursor, new_win, { symbol.lnum, symbol.col - 1 })
+            vim.cmd("normal! zz")
+          end
+          M.clear_preview_highlight()
+          return false
+        end
+      end,
+      desc = "Open in horizontal split",
+    },
+    {
       key = "<C-o>",
       handler = function(items_or_item)
         if type(items_or_item) == "table" and items_or_item[1] then

--- a/lua/namu/namu_symbols/init.lua
+++ b/lua/namu/namu_symbols/init.lua
@@ -275,13 +275,13 @@ M.config = {
     },
     {
       key = "<C-v>",
-      handler = function(item, state)
+      handler = function(item, selecta_state)
         if not state.original_buf then
           vim.notify("No original buffer available", vim.log.levels.ERROR)
           return
         end
 
-        local new_win = selecta.open_in_split(state, item, "vertical")
+        local new_win = selecta.open_in_split(selecta_state, item, "vertical", state)
         if new_win then
           local symbol = item.value
           if symbol and symbol.lnum and symbol.col then

--- a/lua/namu/selecta/selecta.lua
+++ b/lua/namu/selecta/selecta.lua
@@ -1897,4 +1897,42 @@ function M.setup(opts)
   })
 end
 
+---Open current buffer in a split and jump to the selected symbol's location
+---@param state SelectaState The current picker state
+---@param item SelectaItem The LSP symbol item to jump to
+---@param split_type? "vertical"|"horizontal" The type of split to create (defaults to horizontal)
+---@param module_state NamuState The state from the calling module
+---@return number|nil window_id The new window ID if successful
+function M.open_in_split(state, item, split_type, module_state)
+  if not item then
+    return nil
+  end
+
+  -- Use module_state for original window and position if available
+  local original_win = module_state.original_win and module_state.original_win or vim.api.nvim_get_current_win()
+  local original_pos = module_state.original_pos and module_state.original_pos or vim.api.nvim_win_get_cursor(0)
+  local current_buf = module_state.original_buf and module_state.original_buf or vim.api.nvim_get_current_buf()
+
+  -- Close the picker
+  M.close_picker(state)
+
+  -- First focus the original window and restore cursor position
+  if original_win and vim.api.nvim_win_is_valid(original_win) then
+    vim.api.nvim_set_current_win(original_win)
+    pcall(vim.api.nvim_win_set_cursor, original_win, original_pos)
+  end
+
+  -- Create the split
+  local split_cmd = split_type == "vertical" and "vsplit" or "split"
+  vim.cmd(split_cmd)
+
+  -- Get the new window ID
+  local new_win = vim.api.nvim_get_current_win()
+
+  -- Set up the new window
+  vim.api.nvim_win_set_buf(new_win, current_buf)
+
+  return new_win
+end
+
 return M


### PR DESCRIPTION
Hi,

I really like your plugin. Having used Zed, I think it is a great way to explore the lsp symbols.

I noticed that `open_in_split` was not implemented when trying to open a symbol in a vertical split. So I went ahead and implemented one for your consideration, allowing to preserve the original cursor position in the current window.