### PR TITLE
fix(workspace): set alternate buffer '#'

### DIFF
--- a/lua/namu/namu_workspace/impl.lua
+++ b/lua/namu/namu_workspace/impl.lua
@@ -412,6 +412,8 @@ function impl.show_with_query(config, query, opts)
               })
               api.nvim_win_call(state.original_win, function()
                 vim.cmd("normal! zz")
+                -- Set alternate buffer
+                vim.fn.setreg("#", state.original_buf)
               end)
             end
           end)


### PR DESCRIPTION
Hi @bassamsdata,

Currently, I noticed that when using `Namu workspace` and select a symbol from a file that is not opened yet, it would open correctly but then I cannot go back to the previous one with `:e#`, due to the alternate buffer not being set and therefore getting this error: `E194: No alternate file name to substitute for '#'`.

This pull request fixes that.

For your consideration!