### PR TITLE
Show structs by default in Rust

### DIFF
--- a/lua/namu/namu_symbols/config.lua
+++ b/lua/namu/namu_symbols/config.lua
@@ -32,6 +32,7 @@ M.defaults = {
       "Function",
       "Method",
       "Class",
+      "Struct",
       "Module",
       "Property",
       "Variable",


### PR DESCRIPTION
I have been loving this plugin! However, in Rust, structs should ideally be shown by default.