### PR TITLE
Add optional jump labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 {
     "bassamsdata/namu.nvim",
     opts = {
-        global = { },
+        global = {
+            -- jump = { enabled = true }, -- opt-in: one-key jump labels, toggle with `;`
+        },
         namu_symbols = { -- Specific Module options
             options = {},
         },
@@ -226,6 +228,14 @@ You can check the [configuration documentation](https://github.com/bassamsdata/n
 { -- Those are the default options
   "bassamsdata/namu.nvim",
     opts = {
+    -- global options apply to every picker
+      global = {
+        jump = {
+          enable = false, -- opt-in: one-key jump labels
+          toggle_key = ";", -- press in any picker to toggle label mode
+          auto_activate = false, -- enter jump mode immediately on open
+        }
+      },
       -- Enable symbols navigator which is the default
       namu_symbols = {
         enable = true,

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ## Make It Yours
 
-You can check the [configuration documentation](https://github.com/bassamsdata/namu.nvim/tree/main/docs/Namu_config.md) for details on each option.
+You can check the [configuration documentation](https://github.com/bassamsdata/namu.nvim/tree/main/doc/Namu_config.md) for details on each option.
 <details>
   <summary>Here's the full setup with defaults:</summary>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://github.com/user-attachments/assets/a97ff3b1-8b25-4da1-b276-f623e37d0368
 ## What Makes It Special
 
 - 🔍 **Live Preview**: See exactly where you'll land before you jump
+- 🏷 **Jump Labels**: One-key jump to any visible row via per-row labels (opt-in toggle, default `;`)
 - 🌳 **Order Preservation**: Maintains symbol order as they appear in your code, even after filtering
 - 🗂️ **Hierarchy Preservation**: Keeps the parent-child structure of your code symbols intact, so you always see context.
 - 📐 **Smart Auto-resize**: Window adapts to your content in real-time as you type and filter, no need for a big window with only a couple of items

--- a/doc/Namu_config.md
+++ b/doc/Namu_config.md
@@ -105,6 +105,76 @@ If only one item remains after filtering, automatically select it.
 auto_select = false,
 ```
 
+## Jump Labels
+Leap-style one-key jumping: place a label character on every visible row,
+press the label to jump to that row and select it in one keystroke.
+
+Off by default; enable globally to bind the toggle key (`;`) on every
+selecta-based picker:
+
+```lua
+require("namu").setup({
+  global = {
+    jump = { enabled = true },
+  },
+})
+```
+
+Press the toggle key (default `;`) in any picker to enter label mode; press
+again or `<Esc>` to exit. Label keystroke selects the labelled row, fires
+`on_select`, and closes the picker. While labels are showing the prompt
+buffer is locked so the filter can't change underfoot. Multiselect (`Tab`)
+is intentionally inert during jump mode — labels are always single-select;
+your prior `Tab` selections are preserved for when you toggle out.
+
+### Auto-activate (per-module)
+
+Some pickers benefit from entering jump mode immediately so single-key
+picks land in one stroke (code actions, buffer picker, spell suggestions):
+
+```lua
+require("namu").setup({
+  global    = { jump = { enabled = true } },
+  ui_select = {
+    enable  = true,
+    options = {
+      jump = {
+        auto_activate = true,
+        -- Suppress auto-activate for specific vim.ui.select kinds.
+        skip_kinds = { confirmation = true },
+      },
+    },
+  },
+})
+```
+
+### Per-call override
+
+`vim.tbl_deep_extend` means callers can override any field on a single call
+without knowing the rest of the config:
+
+```lua
+vim.ui.select(items, {
+  prompt = "Confirm:",
+  jump   = { auto_activate = false }, -- this one picker won't auto-jump
+}, on_choice)
+```
+
+### Full config surface
+
+```lua
+jump = {
+  enabled       = false, -- master opt-in; everything below is dead unless true
+  toggle_key    = ";",   -- key that enters/exits jump mode
+  auto_activate = false, -- enter jump immediately when the picker opens
+  keys          = "asdfghjklqwertyuiopzxcvbnmASDFGHJKLQWERTYUIOPZXCVBNM",
+  hl_group      = "NamuJumpLabel", -- highlight group used for the labels
+  priority      = 300,             -- extmark priority for the labels
+  min_items     = 0,               -- skip jump if fewer visible items than this
+  skip_kinds    = {},              -- table<vim.ui.select kind, true> to skip auto_activate
+},
+```
+
 ## Preserve Order
 Determines whether symbols maintain their original order after filtering.
 

--- a/doc/Namu_config.md
+++ b/doc/Namu_config.md
@@ -174,6 +174,52 @@ jump = {
   skip_kinds    = {},              -- table<vim.ui.select kind, true> to skip auto_activate
 },
 ```
+### Recipe: differentiated setup
+
+A real-world setup rarely wants the same behaviour everywhere. Because
+`global` propagates to every picker and per-module settings win over it, you
+can mix toggle-only pickers with auto-jumping ones in a single `setup()`:
+
+```lua
+require("namu").setup({
+  -- Jump on everywhere; bind the toggle key on every picker.
+  global = {
+    jump = {
+      enabled    = true,
+      toggle_key = ";",
+      -- Home-row-first labels. NEVER include the toggle_key in `keys` — a
+      -- label keymap would shadow the binding that exits jump mode.
+      keys       = "asdfghjklqwertyuiopzxcvbnm",
+      min_items  = 3, -- 1–2 visible rows? just press <CR>, skip labelling.
+    },
+  },
+
+  -- Symbol pickers inherit the global config above: toggle-only. You
+  -- typically type to filter first, then press `;` once the target is on
+  -- screen — so auto_activate stays off here.
+
+  -- vim.ui.select (LSP code actions, etc.): drop straight into label mode so
+  -- a single keystroke picks.
+  ui_select = {
+    enable  = true,
+    options = {
+      jump = {
+        auto_activate = true,
+        min_items     = 2, -- a lone code action is still taken with <CR>.
+        -- Suppress auto_activate for specific vim.ui.select kinds — e.g. a
+        -- destructive picker where you'd rather read before a key lands.
+        skip_kinds    = { codeaction = true },
+      },
+    },
+  },
+})
+
+-- Make the labels pop (NamuJumpLabel links to "Special" by default).
+vim.api.nvim_set_hl(0, "NamuJumpLabel", { fg = "#ff966c", bold = true })
+```
+
+`skip_kinds` only gates `auto_activate`: a skipped kind still enters jump
+mode the moment you press the toggle key — it just won't do so on its own.
 
 ## Preserve Order
 Determines whether symbols maintain their original order after filtering.

--- a/doc/namu.txt
+++ b/doc/namu.txt
@@ -59,6 +59,7 @@ https://github.com/user-attachments/assets/a97ff3b1-8b25-4da1-b276-f623e37d0368
 WHAT MAKES IT SPECIAL                   *namu-namu.nvim-what-makes-it-special*
 
 - 🔍 **Live Preview**: See exactly where you’ll land before you jump
+- 🏷 **Jump Labels**: One-key jump to any visible row via per-row labels (opt-in toggle, default `;`)
 - 🌳 **Order Preservation**: Maintains symbol order as they appear in your code, even after filtering
 - 🗂️ **Hierarchy Preservation**: Keeps the parent-child structure of your code symbols intact, so you always see context.
 - 📐 **Smart Auto-resize**: Window adapts to your content in real-time as you type and filter, no need for a big window with only a couple of items

--- a/lua/namu/core/config_manager.lua
+++ b/lua/namu/core/config_manager.lua
@@ -143,6 +143,10 @@ M.module_defaults = {
       padding = 0,
       show_numbers = true,
     },
+    jump = {
+      enabled = false,
+      auto_activate = false,
+    },
   },
 }
 

--- a/lua/namu/core/highlights.lua
+++ b/lua/namu/core/highlights.lua
@@ -98,6 +98,7 @@ function M.setup()
     NamuEmptyIndicator = "Comment", -- Empty selection indicator
     NamuFooter = "Comment", -- Footer text
     NamuCurrentItem = "CursorLine", -- Highlight the current item
+    NamuJumpLabel = "Special", -- Jump-mode label characters
     -- NamuCurrentItemIcon = "NamuCurrentItem", -- Icon highlight, defaults to current item, overridden when custom colors are used
     -- Namu Symbols
     NamuPrefixSymbol = "@Comment",

--- a/lua/namu/selecta/input.lua
+++ b/lua/namu/selecta/input.lua
@@ -442,9 +442,19 @@ end
 function M.setup_multiselect_keymaps(state, opts, close_picker_fn, process_query_fn, map_key)
   local multiselect_keys = opts.multiselect.keymaps or config.multiselect.keymaps
 
+  -- While jump mode is active, multiselect is intentionally inert: the user
+  -- is picking a single target by label, not building a selection set.
+  -- Keymaps stay bound so they snap back as soon as jump mode exits.
+  local function jump_active()
+    return state.jump ~= nil and state.jump.active == true
+  end
+
   -- Toggle selection
   if multiselect_keys.toggle then
     map_key(multiselect_keys.toggle, function()
+      if jump_active() then
+        return
+      end
       handle_toggle(state, opts, 1)
     end)
   end
@@ -452,6 +462,9 @@ function M.setup_multiselect_keymaps(state, opts, close_picker_fn, process_query
   -- Untoggle selection
   if multiselect_keys.untoggle then
     map_key(multiselect_keys.untoggle, function()
+      if jump_active() then
+        return
+      end
       handle_untoggle(state, opts)
     end)
   end
@@ -459,6 +472,9 @@ function M.setup_multiselect_keymaps(state, opts, close_picker_fn, process_query
   -- Select all
   if multiselect_keys.select_all then
     map_key(multiselect_keys.select_all, function()
+      if jump_active() then
+        return
+      end
       bulk_selection(state, opts, true)
       process_query_fn(state, opts)
     end)
@@ -467,6 +483,9 @@ function M.setup_multiselect_keymaps(state, opts, close_picker_fn, process_query
   -- Clear all selections
   if multiselect_keys.clear_all then
     map_key(multiselect_keys.clear_all, function()
+      if jump_active() then
+        return
+      end
       bulk_selection(state, opts, false)
       process_query_fn(state, opts)
     end)

--- a/lua/namu/selecta/jump.lua
+++ b/lua/namu/selecta/jump.lua
@@ -1,0 +1,144 @@
+-- Jump-label support for selecta pickers (one-key jumping to any visible row).
+-- Opt-in: no-op unless `opts.jump.enabled = true`.
+
+local M = {}
+local common = require("namu.selecta.common")
+
+function M.is_active(state)
+    return state and state.jump and state.jump.active or false
+end
+
+function M.activate(state, opts)
+    if M.is_active(state) or not state.active or state.is_loading then
+        return
+    end
+    local jump_opts = opts.jump
+    if #state.filtered_items < math.max(1, jump_opts.min_items or 0) then
+        return
+    end
+
+    state.jump = state.jump or {}
+    state.jump.active = true
+    state.jump.ns = state.jump.ns
+        or vim.api.nvim_create_namespace("namu_jump_" .. tostring(state.picker_id))
+    state.jump.bound_keys = {}
+    state.jump.prev_modifiable = vim.bo[state.prompt_buf].modifiable
+
+    -- Lock the prompt buffer (so unbound keys can't edit the filter) and drop
+    -- out of insert mode (so the normal-mode label keymaps below fire).
+    vim.bo[state.prompt_buf].modifiable = false
+    vim.cmd("stopinsert")
+
+    -- Place a label per visible row, bind a normal-mode keymap per label.
+    -- Label presses are always single-select: move cursor to the row (so
+    -- previews recentre via on_move), close, then fire on_select with the
+    -- target item. Multiselect users keep using their Tab binding.
+    local win_info = vim.fn.getwininfo(state.win)[1]
+    local labels = jump_opts.keys
+    for i = 1, #labels do
+        local row = win_info.topline + i - 1
+        if row > win_info.botline or not state.filtered_items[row] then
+            break
+        end
+        local key = labels:sub(i, i)
+        table.insert(state.jump.bound_keys, key)
+        vim.api.nvim_buf_set_extmark(state.buf, state.jump.ns, row - 1, 0, {
+            virt_text = { { key, jump_opts.hl_group } },
+            virt_text_pos = "overlay",
+            priority = jump_opts.priority,
+        })
+        vim.keymap.set("n", key, function()
+            if not state.active then
+                return
+            end
+            local item = state.filtered_items[row]
+            vim.api.nvim_win_set_cursor(state.win, { row, 0 })
+            common.update_current_highlight(state, opts, row - 1)
+            if opts.on_move then
+                opts.on_move(item)
+            end
+            common.close_picker_with_cleanup(state, opts, require("namu.selecta.selecta").close_picker, false)
+            if opts.on_select then
+                opts.on_select(item)
+            end
+        end, {
+            buffer = state.prompt_buf,
+            nowait = true,
+            silent = true,
+            desc = "Namu: Jump label " .. key,
+        })
+    end
+end
+
+function M.deactivate(state)
+    if not M.is_active(state) then
+        return
+    end
+    state.jump.active = false
+
+    if vim.api.nvim_buf_is_valid(state.buf) then
+        vim.api.nvim_buf_clear_namespace(state.buf, state.jump.ns, 0, -1)
+    end
+    for _, key in ipairs(state.jump.bound_keys) do
+        pcall(vim.keymap.del, "n", key, { buffer = state.prompt_buf })
+    end
+    state.jump.bound_keys = {}
+
+    if vim.api.nvim_buf_is_valid(state.prompt_buf) then
+        vim.bo[state.prompt_buf].modifiable = state.jump.prev_modifiable ~= false
+    end
+
+    -- Re-enter insert mode only if the prompt window still owns the focus —
+    -- skipped during cleanup-driven deactivation where the window is going away.
+    if
+        state.active
+        and vim.api.nvim_win_is_valid(state.prompt_win)
+        and vim.api.nvim_get_current_win() == state.prompt_win
+    then
+        vim.cmd("startinsert")
+    end
+end
+
+---Register the toggle key (i+n) and normal-mode close mirrors so <Esc>
+---cancels from jump mode. No-op when jump is disabled.
+function M.setup_keymap(state, opts)
+    local jump_opts = opts.jump
+    if not (jump_opts and jump_opts.enabled) then
+        return
+    end
+
+    -- Toggle must work in BOTH modes: insert to enter, normal to exit (jump
+    -- itself runs in normal mode, so an n-binding is the only way out).
+    vim.keymap.set({ "i", "n" }, jump_opts.toggle_key, function()
+        if not state.active then
+            return
+        end
+        if M.is_active(state) then
+            M.deactivate(state)
+        else
+            M.activate(state, opts)
+        end
+    end, {
+        buffer = state.prompt_buf,
+        nowait = true,
+        silent = true,
+        desc = "Namu: Toggle jump mode",
+    })
+
+    -- selecta binds close keys insert-only by default; mirror into normal mode
+    -- so <Esc> cancels even while labels are showing.
+    for _, key in ipairs((opts.movement and opts.movement.close) or { "<ESC>" }) do
+        vim.keymap.set("n", key, function()
+            if state.active then
+                common.close_picker_with_cleanup(state, opts, require("namu.selecta.selecta").close_picker, true)
+            end
+        end, {
+            buffer = state.prompt_buf,
+            nowait = true,
+            silent = true,
+            desc = "Namu: Cancel (from jump mode)",
+        })
+    end
+end
+
+return M

--- a/lua/namu/selecta/selecta.lua
+++ b/lua/namu/selecta/selecta.lua
@@ -495,6 +495,9 @@ function M.setup_prompt_buffer(state, opts)
   })
 
   input_handler.setup_keymaps(state, opts, M.close_picker, M.process_query)
+  if opts.jump and opts.jump.enabled then
+    require("namu.selecta.jump").setup_keymap(state, opts)
+  end
   ui.update_prompt_prefix(state, opts, state:get_query_string())
   vim.cmd("startinsert")
 end
@@ -521,6 +524,7 @@ function M.pick(items, opts)
     row_position = config.row_position,
     debug = config.debug,
     normal_mode = false,
+    jump = config.jump,
   }
   opts = vim.tbl_deep_extend("force", base_opts, opts or {})
 
@@ -569,6 +573,13 @@ function M.pick(items, opts)
   -- Initial processing
   M.process_query(state, opts)
   vim.cmd("redraw")
+
+  -- Optional auto-activation: jump.activate() runs stopinsert which cancels
+  -- the setup_prompt_buffer startinsert in the same synchronous chain, so we
+  -- exit pick() already in normal mode with labels rendered.
+  if opts.jump and opts.jump.enabled and opts.jump.auto_activate then
+    require("namu.selecta.jump").activate(state, opts)
+  end
 
   -- Handle initial cursor position
   if opts.initial_index and opts.initial_index <= #items then

--- a/lua/namu/selecta/selecta_config.lua
+++ b/lua/namu/selecta/selecta_config.lua
@@ -67,6 +67,16 @@ M.defaults = {
     text = "Loading results...",
     icon = "󰇚",
   },
+  jump = {
+    enabled = false, -- master opt-in
+    toggle_key = ";", -- key to enter/exit jump mode
+    auto_activate = false, -- enter jump mode immediately on pick()
+    keys = "asdfghjklqwertyuiopzxcvbnmASDFGHJKLQWERTYUIOPZXCVBNM",
+    hl_group = "NamuJumpLabel",
+    priority = 300,
+    min_items = 0, -- skip jump mode if fewer visible items than this
+    skip_kinds = {}, -- map of vim.ui.select kinds to skip auto_activate for
+  },
 }
 
 -- Active configuration (will be updated via setup)

--- a/lua/namu/selecta/selecta_types.lua
+++ b/lua/namu/selecta/selecta_types.lua
@@ -131,6 +131,17 @@
 ---@field items_fully_loaded? boolean Whether all items have been loaded (async)
 ---@field on_close? fun() Function to call when picker closes
 ---@field logical_item_counter? fun(items: SelectaItem[]): number Custom function to count logical items (for multiline/grouped items)
+---@field jump? SelectaJumpConfig Optional jump-label configuration
+
+---@class SelectaJumpConfig
+---@field enabled? boolean Master opt-in. When false (default), jump module is a no-op.
+---@field toggle_key? string Key that toggles jump mode in the prompt buffer. Default ";"
+---@field auto_activate? boolean Enter jump mode immediately when the picker opens. Default false.
+---@field keys? string Ordered string of label characters. One label per visible row.
+---@field hl_group? string Highlight group used for the label virt_text. Default "NamuJumpLabel".
+---@field priority? number Extmark priority for the labels. Default 300.
+---@field min_items? number Skip jump mode if fewer than this many items are visible.
+---@field skip_kinds? table<string, boolean> Map of vim.ui.select kinds for which auto_activate is suppressed.
 
 ---@class CurrentHighlightConfig
 ---@field enabled boolean Whether to use custom highlight

--- a/lua/namu/selecta/state.lua
+++ b/lua/namu/selecta/state.lua
@@ -269,6 +269,11 @@ end
 
 ---Clean up resources when closing the picker
 function StateManager:cleanup()
+  -- Tear down jump mode (if active) before the prompt buffer/window go away.
+  -- Lazy-required to avoid a load-time cycle.
+  if self.jump and self.jump.active then
+    require("namu.selecta.jump").deactivate(self)
+  end
   -- Clear all highlights in all namespaces
   if self.buf and vim.api.nvim_buf_is_valid(self.buf) then
     vim.api.nvim_buf_clear_namespace(self.buf, common.ns_id, 0, -1)

--- a/lua/namu/ui_select/ui_select.lua
+++ b/lua/namu/ui_select/ui_select.lua
@@ -164,6 +164,13 @@ function M.select(items, opts, on_choice)
     })
   end
 
+  -- Resolve jump options for this call: honour module defaults, but suppress
+  -- auto_activate for kinds the user has opted out of (e.g. confirmations).
+  local jump_for_call = M.config.jump
+  if jump_for_call and jump_for_call.skip_kinds and opts.kind and jump_for_call.skip_kinds[opts.kind] then
+    jump_for_call = vim.tbl_extend("force", jump_for_call, { auto_activate = false })
+  end
+
   -- Configure Selecta options
   local default_selecta_opts = {
     title = opts.prompt or M.config.title,
@@ -174,6 +181,7 @@ function M.select(items, opts, on_choice)
     current_highlight = M.config.current_highlight,
     row_position = M.config.row_position or "top10",
     formatter = create_custom_formatter(M.config),
+    jump = jump_for_call,
     -- Custom offset function to account for numbering
     offset = function(item)
       local total_offset = 0

--- a/tests/test_jump.lua
+++ b/tests/test_jump.lua
@@ -1,0 +1,288 @@
+---@diagnostic disable: need-check-nil, param-type-mismatch
+local h = require("tests.helpers")
+local selecta = require("namu.selecta.selecta")
+local jump = require("namu.selecta.jump")
+local selecta_config = require("namu.selecta.selecta_config")
+local StateManager = require("namu.selecta.state").StateManager
+---@diagnostic disable-next-line: undefined-global
+local new_set = MiniTest.new_set
+
+local T = new_set()
+
+-- Force highlights to be set up so NamuJumpLabel exists for extmark validation.
+require("namu.core.highlights").setup()
+
+-- selecta.pick is fire-and-forget — it doesn't expose state. Tests need a
+-- handle to the SelectaState to drive activate/deactivate/etc., so we
+-- transiently monkey-patch StateManager.new to capture it. The patch is
+-- reverted before pick() returns; isolation is contained to this helper.
+local last_state = nil
+local function open_picker(items, opts)
+  local original_new = StateManager.new
+  StateManager.new = function(...)
+    last_state = original_new(...)
+    return last_state
+  end
+  local ok, err = pcall(selecta.pick, items, opts or {})
+  StateManager.new = original_new
+  if not ok then
+    error(err)
+  end
+  return last_state
+end
+
+local function close_picker()
+  if last_state and last_state.active then
+    pcall(selecta.close_picker, last_state)
+  end
+  -- The picker leaves floating windows and unlisted scratch buffers around;
+  -- delete both so the next test starts on the original buffer.
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if vim.api.nvim_win_is_valid(win) then
+      local cfg = vim.api.nvim_win_get_config(win)
+      if cfg.relative ~= "" then
+        pcall(vim.api.nvim_win_close, win, true)
+      end
+    end
+  end
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      local listed = vim.api.nvim_get_option_value("buflisted", { buf = bufnr })
+      if not listed then
+        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+      end
+    end
+  end
+  pcall(vim.cmd, "stopinsert")
+end
+
+local function items_for(n)
+  local items = {}
+  for i = 1, n do
+    items[i] = { text = string.format("item-%02d", i), value = i, id = "id-" .. i }
+  end
+  return items
+end
+
+local picker_hooks = {
+  pre_case = function()
+    selecta_config.values = vim.deepcopy(selecta_config.defaults)
+    last_state = nil
+  end,
+  post_case = function()
+    close_picker()
+    last_state = nil
+  end,
+}
+
+-- ----------------------------------------------------------------------
+T["Jump.config"] = new_set()
+
+T["Jump.config"]["defaults register a disabled jump table"] = function()
+  selecta.setup({})
+  local config = selecta.get_config()
+  h.eq(type(config.jump), "table")
+  h.eq(config.jump.enabled, false)
+  h.eq(config.jump.toggle_key, ";")
+  h.eq(config.jump.auto_activate, false)
+  h.eq(type(config.jump.keys), "string")
+  h.eq(#config.jump.keys > 0, true)
+end
+
+T["Jump.config"]["user setup merges jump overrides"] = function()
+  selecta.setup({ jump = { enabled = true, toggle_key = "/" } })
+  local config = selecta.get_config()
+  h.eq(config.jump.enabled, true)
+  h.eq(config.jump.toggle_key, "/")
+  h.eq(config.jump.auto_activate, false) -- defaults preserved
+  selecta_config.values = vim.deepcopy(selecta_config.defaults)
+end
+
+-- ----------------------------------------------------------------------
+T["Jump.activation"] = new_set({ hooks = picker_hooks })
+
+T["Jump.activation"]["is_active is false on a fresh picker"] = function()
+  local state = open_picker(items_for(5), { jump = { enabled = true } })
+  h.eq(jump.is_active(state), false)
+end
+
+T["Jump.activation"]["activate places one extmark per visible row"] = function()
+  local opts = { jump = selecta.get_config().jump }
+  local state = open_picker(items_for(5), opts)
+  jump.activate(state, opts)
+  h.eq(jump.is_active(state), true)
+  local marks = vim.api.nvim_buf_get_extmarks(state.buf, state.jump.ns, 0, -1, { details = true })
+  h.eq(#marks, 5, "one label per visible row")
+  for _, mark in ipairs(marks) do
+    h.eq(mark[4].virt_text[1][2], "NamuJumpLabel")
+  end
+end
+
+T["Jump.activation"]["activate locks the prompt buffer"] = function()
+  local opts = { jump = selecta.get_config().jump }
+  local state = open_picker(items_for(3), opts)
+  jump.activate(state, opts)
+  h.eq(vim.bo[state.prompt_buf].modifiable, false)
+end
+
+T["Jump.activation"]["deactivate clears labels and unbinds keys"] = function()
+  local opts = { jump = selecta.get_config().jump }
+  local state = open_picker(items_for(4), opts)
+  jump.activate(state, opts)
+  local first_key = opts.jump.keys:sub(1, 1)
+
+  local function has_normal_keymap(key)
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(state.prompt_buf, "n")) do
+      if m.lhs == key then
+        return true
+      end
+    end
+    return false
+  end
+
+  h.eq(has_normal_keymap(first_key), true, "label key bound after activate")
+
+  jump.deactivate(state)
+  h.eq(jump.is_active(state), false)
+  h.eq(vim.bo[state.prompt_buf].modifiable, true)
+  local marks = vim.api.nvim_buf_get_extmarks(state.buf, state.jump.ns, 0, -1, {})
+  h.eq(#marks, 0)
+  h.eq(has_normal_keymap(first_key), false, "label key unbound after deactivate")
+end
+
+T["Jump.activation"]["activate is a no-op when min_items not satisfied"] = function()
+  local opts = { jump = { enabled = true, min_items = 5 } }
+  local state = open_picker({ { text = "only-one", value = 1, id = "id-1" } }, opts)
+  jump.activate(state, opts)
+  h.eq(jump.is_active(state), false)
+end
+
+-- ----------------------------------------------------------------------
+T["Jump.toggle_key"] = new_set({ hooks = picker_hooks })
+
+local function buf_keymap_has(bufnr, mode, lhs)
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode)) do
+    if m.lhs == lhs then
+      return true
+    end
+  end
+  return false
+end
+
+T["Jump.toggle_key"]["setup_keymap binds toggle key in insert mode"] = function()
+  local state = open_picker(items_for(3), { jump = { enabled = true, toggle_key = ";" } })
+  h.eq(buf_keymap_has(state.prompt_buf, "i", ";"), true)
+end
+
+T["Jump.toggle_key"]["setup_keymap binds toggle key in normal mode too"] = function()
+  -- Required so the user can toggle OUT of jump mode (jump runs in normal
+  -- mode; without an n-mode binding `;` does nothing and the user is stuck).
+  local state = open_picker(items_for(3), { jump = { enabled = true, toggle_key = ";" } })
+  h.eq(buf_keymap_has(state.prompt_buf, "n", ";"), true)
+end
+
+T["Jump.toggle_key"]["close keys are mirrored into normal mode"] = function()
+  -- selecta binds <Esc> insert-only by default; jump must extend it into
+  -- normal mode so <Esc> cancels the picker even while labels are showing.
+  local state = open_picker(items_for(3), {
+    jump = { enabled = true },
+    movement = { close = { "<ESC>" } },
+  })
+  h.eq(buf_keymap_has(state.prompt_buf, "n", "<Esc>"), true)
+end
+
+T["Jump.toggle_key"]["setup_keymap is a no-op when jump disabled"] = function()
+  local state = open_picker(items_for(3), {})
+  h.eq(buf_keymap_has(state.prompt_buf, "i", ";"), false)
+  h.eq(buf_keymap_has(state.prompt_buf, "n", ";"), false)
+end
+
+-- ----------------------------------------------------------------------
+T["Jump.selection"] = new_set({ hooks = picker_hooks })
+
+T["Jump.selection"]["label invokes on_move then on_select with the right item"] = function()
+  local move_calls, select_calls = {}, {}
+  local opts = {
+    jump = selecta.get_config().jump,
+    on_move = function(item) table.insert(move_calls, item.value) end,
+    on_select = function(item) table.insert(select_calls, item.value) end,
+  }
+  local state = open_picker(items_for(4), opts)
+  jump.activate(state, opts)
+  -- Selecta fires on_move once during initial render; reset so we only count
+  -- the calls the label-press handler makes.
+  move_calls = {}
+  -- Fire the first label's keymap callback directly.
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(state.prompt_buf, "n")) do
+    if m.lhs == opts.jump.keys:sub(1, 1) and m.callback then
+      m.callback()
+      break
+    end
+  end
+  h.eq(select_calls, { state.filtered_items[1].value })
+  h.eq(move_calls, { state.filtered_items[1].value })
+  h.eq(state.active, false)
+end
+
+-- ----------------------------------------------------------------------
+T["Jump.auto_activate"] = new_set({ hooks = picker_hooks })
+
+T["Jump.auto_activate"]["pick enters jump mode synchronously"] = function()
+  local state = open_picker(items_for(3), { jump = { enabled = true, auto_activate = true } })
+  -- No vim.wait — auto_activate is now a synchronous call inside pick().
+  h.eq(jump.is_active(state), true)
+end
+
+T["Jump.auto_activate"]["disabled jump skips auto_activate even when flag is set"] = function()
+  -- auto_activate is gated behind `enabled`. Setting only auto_activate=true
+  -- must be a no-op so callers can't accidentally turn it on.
+  local state = open_picker(items_for(3), { jump = { auto_activate = true } })
+  h.eq(jump.is_active(state), false)
+end
+
+-- ----------------------------------------------------------------------
+T["Jump.multiselect"] = new_set({ hooks = picker_hooks })
+
+local function fire_normal_keymap(bufnr, lhs)
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+    if m.lhs == lhs and m.callback then
+      m.callback()
+      return true
+    end
+  end
+  return false
+end
+
+T["Jump.multiselect"]["toggle keymap no-ops while jump is active"] = function()
+  local state = open_picker(items_for(4), {
+    jump = { enabled = true },
+    -- normal_mode = true so multiselect Tab is also bound in normal mode,
+    -- which is the only scenario where the keys could otherwise fire while
+    -- jump mode (a normal-mode mode) is active.
+    normal_mode = true,
+    multiselect = {
+      enabled = true,
+      selected_icon = "● ",
+      unselected_icon = "○ ",
+      keymaps = { toggle = "<Tab>" },
+    },
+  })
+  -- Sanity: outside jump, Tab toggles selection on the cursor row.
+  h.eq(state.selected_count, 0)
+  h.eq(fire_normal_keymap(state.prompt_buf, "<Tab>"), true)
+  h.eq(state.selected_count, 1)
+
+  -- Clear the selection so we can prove the next Tab does nothing.
+  state.selected = {}
+  state.selected_count = 0
+
+  jump.activate(state, { jump = selecta.get_config().jump })
+  fire_normal_keymap(state.prompt_buf, "<Tab>")
+  h.eq(state.selected_count, 0, "Tab must not toggle selection during jump")
+
+  jump.deactivate(state)
+  fire_normal_keymap(state.prompt_buf, "<Tab>")
+  h.eq(state.selected_count, 1, "Tab must toggle selection again after jump exits")
+end
+
+return T


### PR DESCRIPTION
### Summary

Adds an opt-in jump-label mode to Namu's selecta picker: press a toggle key to drop a single-character label onto every visible row, then press that label to jump to the row and select it in one keystroke. Off by default — no behavior changes unless you turn it on.

### Motivation

Today, picking a non-top result means filtering further or arrowing/Ctrl-n-ing down to it. With jump labels you can reach any visible row with one keypress. It's especially handy for short, stable lists (code actions, buffer picker, spell suggestions) where the candidates are right there on screen.

### How it works

- A new lua/namu/selecta/jump.lua module owns the whole lifecycle: activate / deactivate / is_active / setup_keymap.
- On activation it places one extmark label per visible row (using topline/botline from getwininfo), binds a normal-mode keymap per label, locks the prompt buffer (so stray keys can't change the filter), and stopinserts so the label keymaps fire.
- Pressing a label moves the cursor to that row (so previews re-centre via on_move), closes the picker, and fires on_select with the target item — always a single select.
- The toggle key (; by default) is bound in both insert and normal mode so you can enter from typing and exit from label mode; <Esc> (and any configured close key) is mirrored into normal mode to cancel.

### Integration points

- selecta.lua — wires setup_keymap into prompt-buffer setup and threads config.jump through pick(); supports synchronous auto_activate on open.
- state.lua cleanup() — tears down jump mode (clears ext-marks, unbinds keys, restores modifiable) before the buffer/window go away.
- input.lua — multi-select keymaps (Tab etc.) become inert while jump is active; they stay bound so prior selections snap back when you toggle out.
- ui_select.lua — vim.ui.select honors module jump defaults and suppresses auto_activate for opted-out kinds (e.g. confirmations).
- highlights.lua — new NamuJumpLabel group (defaults to Special).

### Configuration

Enable globally:

```lua
  require("namu").setup({
    global = { jump = { enabled = true } },
  })
```

Full surface (all overridable per-call via vim.tbl_deep_extend):

```lua
  jump = {
    enabled       = false, -- master opt-in
    toggle_key    = ";",
    auto_activate = false, -- enter jump mode immediately on open
    keys          = "asdfghjklqwertyuiop...",
    hl_group      = "NamuJumpLabel",
    priority      = 300,
    min_items     = 0,     -- skip jump if fewer visible items than this
    skip_kinds    = {},    -- vim.ui.select kinds to skip auto_activate for
  }
```

### Tests

tests/test_jump.lua (new, 288 lines) covers config defaults/merging, activation (one ext-mark per visible row, prompt lock, min_items gate), toggle-key binding in both modes, close-key mirroring, the no-op-when-disabled paths, label selection (on_move → on_select with correct item), synchronous auto_activate, and multi-select inertness during jump mode.

### Docs

- README.md — feature bullet.
- doc/Namu_config.md — new "Jump Labels" section covering global enable, per-module auto_activate, per-call override, and the full config surface.

### Backwards compatibility

Fully opt-in. enabled = false by default makes setup_keymap and activate no-ops, so existing users see no change.